### PR TITLE
Exception on object w/o __toString method

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -992,8 +992,12 @@ function twig_escape_filter(Twig_Environment $env, $string, $strategy = 'html', 
     }
 
     if (!is_string($string)) {
-        if (is_object($string) && method_exists($string, '__toString')) {
-            $string = (string) $string;
+        if (is_object($string)) {
+            if(method_exists($string, '__toString')){
+                $string = (string) $string;
+            }else{
+                throw new Twig_Error_Syntax('Object cannot be displayed as string (no __toString method available)');
+            }
         } elseif (in_array($strategy, array('html', 'js', 'css', 'html_attr', 'url'))) {
             return $string;
         }


### PR DESCRIPTION
Prevent an ugly 50X error; throw an Syntax Exception when someone tries to display (`{{ xxx }}`) an object that's missing the __toString method.